### PR TITLE
Departure times

### DIFF
--- a/spec/fixtures/vcr_cassettes/DurationService/exists_and_has_an_api_call/takes_destination_params_and_returns_durations_for_each_destination.yml
+++ b/spec/fixtures/vcr_cassettes/DurationService/exists_and_has_an_api_call/takes_destination_params_and_returns_durations_for_each_destination.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://maps.googleapis.com/maps/api/distancematrix/json?departure_time=100000009000&destinations=place_id:ChIJDW4E2OtRaocR6Ny-eVsZRyY%7Cplace_id:ChIJy0LIeaDKa4cRW2sSTH03-bU%7Cplace_id:ChIJe2Rv9PdfaocR-3_TarNZh2M&key=<GOOG_KEY>&origins=Golden,%20CO&traffic_model=pessimistic&units=imperial
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?departure_time=1694529000&destinations=place_id:ChIJDW4E2OtRaocR6Ny-eVsZRyY%7Cplace_id:ChIJy0LIeaDKa4cRW2sSTH03-bU%7Cplace_id:ChIJe2Rv9PdfaocR-3_TarNZh2M&key=<GOOG_KEY>&origins=Golden,%20CO&traffic_model=pessimistic&units=imperial
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 Sep 2023 22:56:07 GMT
+      - Tue, 12 Sep 2023 14:23:17 GMT
       Pragma:
       - no-cache
       Expires:
@@ -41,7 +41,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=106
+      - gfet4t7; dur=115
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -55,20 +55,20 @@ http_interactions:
         \              },\n               \"duration\" : \n               {\n                  \"text\"
         : \"53 mins\",\n                  \"value\" : 3178\n               },\n               \"duration_in_traffic\"
         : \n               {\n                  \"text\" : \"1 hour 3 mins\",\n                  \"value\"
-        : 3771\n               },\n               \"status\" : \"OK\"\n            },\n
+        : 3780\n               },\n               \"status\" : \"OK\"\n            },\n
         \           {\n               \"distance\" : \n               {\n                  \"text\"
         : \"56.6 mi\",\n                  \"value\" : 91080\n               },\n               \"duration\"
         : \n               {\n                  \"text\" : \"1 hour 11 mins\",\n                  \"value\"
         : 4236\n               },\n               \"duration_in_traffic\" : \n               {\n
-        \                 \"text\" : \"1 hour 18 mins\",\n                  \"value\"
-        : 4709\n               },\n               \"status\" : \"OK\"\n            },\n
+        \                 \"text\" : \"1 hour 23 mins\",\n                  \"value\"
+        : 4986\n               },\n               \"status\" : \"OK\"\n            },\n
         \           {\n               \"distance\" : \n               {\n                  \"text\"
         : \"69.0 mi\",\n                  \"value\" : 111076\n               },\n
         \              \"duration\" : \n               {\n                  \"text\"
         : \"1 hour 13 mins\",\n                  \"value\" : 4401\n               },\n
         \              \"duration_in_traffic\" : \n               {\n                  \"text\"
-        : \"1 hour 28 mins\",\n                  \"value\" : 5275\n               },\n
+        : \"1 hour 28 mins\",\n                  \"value\" : 5264\n               },\n
         \              \"status\" : \"OK\"\n            }\n         ]\n      }\n   ],\n
         \  \"status\" : \"OK\"\n}"
-  recorded_at: Mon, 11 Sep 2023 22:56:07 GMT
+  recorded_at: Tue, 12 Sep 2023 14:23:17 GMT
 recorded_with: VCR 6.2.0

--- a/spec/services/duration_service_spec.rb
+++ b/spec/services/duration_service_spec.rb
@@ -2,7 +2,30 @@ require "rails_helper"
 
 RSpec.describe DurationService do
   before(:each) do
-    @service = DurationService.new(100000009000)
+    # Need elapsed seconds since Jan 1 1970, to the start(midnight) of the current day, plus however many seconds for each start destination
+
+    # Date.today.to_time - "1970-01-01T00:00:00Z".to_date.to_time
+
+    # 5 hours : 18000
+    # 15 min : 900
+
+    # 5:30 19800
+    # 5:45 20700
+    # 6:00 21600
+    # 6:15 22500
+    # 6:30 23400
+    # 6:45 24300
+    # 7:00 25200
+    # 7:15 26100
+    # 7:30 27000
+    # 7:45 27900
+    # 8:00 28800
+    # 10:00 36000
+    # UTC adder 25200 (gets you to midnight)
+
+    today_at_time = (Date.today.to_time - "1970-01-01T00:00:00Z".to_date.to_time + 25200 + 28800 + 1800).to_i
+
+    @service = DurationService.new(today_at_time)
   end
 
   describe "exists and has an api call", :vcr do
@@ -16,6 +39,7 @@ RSpec.describe DurationService do
 
     it "takes destination params and returns durations for each destination" do
       result = @service.durations
+      binding.pry
 
       expect(result).to be_a(Hash)
       expect(result).to have_key(:destination_addresses)


### PR DESCRIPTION
- Add comments to the duration service spec calculating the time in seconds since 1970 (per google api specification) until today (this morning midnight) with UTC to MST conversion plus necessary seconds for each morning departure time. 
- Rerecord VCR tape with a departure time of this morning.